### PR TITLE
Only include dist folder in NPM bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/objutil.cjs.js",
   "browser": "dist/objutil.umd.js",
   "jsnext:main": "dist/objutil.es.js",
+  "files": ["dist/"],
   "scripts": {
     "travis-before_install": "npm install -g grunt-cli",
     "travis-test": "grunt jshint && npm test",


### PR DESCRIPTION
Right now, the NPM bundle contains the entire contents of this repository, including the 970KB `big.json` test fixture. This results in the NPM package being 1MB in size.

By only including the contents of the `dist` folder, we can slim this down considerably.